### PR TITLE
auto-merge gha is back to just checking for the pr

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,33 +1,25 @@
 name: Dependabot pull requests
 
-on:
-  workflow_run:
-    workflows: ["Run Tests"]
-    types:
-      - completed
+on: pull_request
 
 jobs:
   dependabot:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
-    # Only trigger if tests have passed on a Dependabot-created PR
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.pull_requests != '' &&
-      startsWith(github.event.workflow_run.head_branch, 'dependabot/') &&
-      github.event.workflow_run.pull_requests[0].user.login == 'dependabot[bot]'
+    if:  ${{github.event.pull_request.user.login == 'dependabot[bot]'}}
     permissions:
       pull-requests: write
       contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
-      - name: Dependabot metadata
-        id: dependabot-metadata
+      - name: Fetch Dependabot Metadata
         uses: dependabot/fetch-metadata@v2
+        id: dependabot-metadata
       - name: Approve and Merge the PR
-        if: ${{ steps.dependabot-metadata.outputs.dependency-group == 'app-dependencies' }}
+        # Don't do this for the container-updates group
+        if: ${{ steps.dependabot-metadata.outputs.dependency-group != 'container-updates' }}
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --squash --auto "$PR_URL"


### PR DESCRIPTION
There is branch protection to keep PRs from getting merged if the tests don't pass. 